### PR TITLE
ci: add package created to manifest package devDeps in new:boi script

### DIFF
--- a/.tpl/boi-package/package.json
+++ b/.tpl/boi-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-javascript-vue2-vant",
-  "version": "0.0.4",
+  "version": "0.0.1",
   "description": "boilerplate-javascript-vue-vant",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/scripts/new/boilerplate.ts
+++ b/scripts/new/boilerplate.ts
@@ -115,6 +115,11 @@ export async function createBoilerplatePackage() {
 
   logger.stopLoading()
 
+  // add new boilerplate package to minifest package.json
+  execa.commandSync(`pnpm add -D ${packageName} --filter @vrn-deco/boilerplate-manifest`, {
+    cwd: _REPO_,
+  })
+
   logger.done(
     `${packageName} created: packages/${path.posix.join(language.toLowerCase(), folderName)}`,
   )


### PR DESCRIPTION
When new boilerplate is executed, Add the created boi-package to the manifest-package devDependencies