### PR TITLE
feat(preset): fallback to npm when third-party pm not exist

### DIFF
--- a/packages/javascript/vue2-element/CHANGELOG.md
+++ b/packages/javascript/vue2-element/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @vrn-deco/boilerplate-javascript-vue2-element
 
+## 2.2.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @vrn-deco/boilerplate-preset-npm@1.1.0
+
+## 2.2.15
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-npm@1.0.6
+
 ## 2.2.14
 
 ### Patch Changes

--- a/packages/javascript/vue2-element/package.json
+++ b/packages/javascript/vue2-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-javascript-vue2-element",
-  "version": "2.2.14",
+  "version": "2.2.16",
   "description": "boilerplate javascript vue2 element",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/javascript/vue2-vant-h5plus/CHANGELOG.md
+++ b/packages/javascript/vue2-vant-h5plus/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @vrn-deco/boilerplate-javascript-vue-vant-h5plus
 
+## 2.2.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @vrn-deco/boilerplate-preset-npm@1.1.0
+
+## 2.2.15
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-npm@1.0.6
+
 ## 2.2.14
 
 ### Patch Changes

--- a/packages/javascript/vue2-vant-h5plus/package.json
+++ b/packages/javascript/vue2-vant-h5plus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-javascript-vue2-vant-h5plus",
-  "version": "2.2.14",
+  "version": "2.2.16",
   "description": "boilerplate-javascript-vue2-vant-h5plus",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/javascript/vue2-vant/CHANGELOG.md
+++ b/packages/javascript/vue2-vant/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @vrn-deco/boilerplate-javascript-vue-vant
 
+## 2.2.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @vrn-deco/boilerplate-preset-npm@1.1.0
+
+## 2.2.15
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-npm@1.0.6
+
 ## 2.2.14
 
 ### Patch Changes

--- a/packages/javascript/vue2-vant/package.json
+++ b/packages/javascript/vue2-vant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-javascript-vue2-vant",
-  "version": "2.2.14",
+  "version": "2.2.16",
   "description": "boilerplate-javascript-vue2-vant",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/typescript/vue3-varlet-h5plus/CHANGELOG.md
+++ b/packages/typescript/vue3-varlet-h5plus/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @vrn-deco/boilerplate-typescript-vue3-varlet-h5plus
 
+## 0.1.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @vrn-deco/boilerplate-preset-npm@1.1.0
+
+## 0.1.9
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-npm@1.0.6
+
 ## 0.1.8
 
 ### Patch Changes

--- a/packages/typescript/vue3-varlet-h5plus/package.json
+++ b/packages/typescript/vue3-varlet-h5plus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-typescript-vue3-varlet-h5plus",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "description": "boilerplate-typescript-vue3-varlet-h5plus",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/presets/base/CHANGELOG.md
+++ b/presets/base/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-preset-base
 
+## 1.1.0
+
+### Minor Changes
+
+- Attached `cmdIsExists` methods
+
 ## 1.0.0
 
 ### Major Changes

--- a/presets/base/package.json
+++ b/presets/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-preset-base",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "boilerplate preset base",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/presets/base/src/index.ts
+++ b/presets/base/src/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import path from 'path'
+import os from 'os'
 import fs from 'fs-extra'
+import { execSync } from 'child_process'
 import minimist from 'minimist'
 import execa from 'execa'
 import { logger } from '@ombro/logger'
@@ -163,6 +165,20 @@ export class BaseRunner implements Runner {
         cwd: this.targetDir,
       },
     )
+  }
+
+  protected cmdIsExists(cmd: string): boolean {
+    try {
+      execSync(
+        os.platform() === 'win32'
+          ? `cmd /c "(help ${cmd} > nul || exit 0) && where ${cmd} > nul 2> nul"`
+          : `command -v ${cmd}`,
+        { stdio: 'ignore' },
+      )
+      return true
+    } catch {
+      return false
+    }
   }
 }
 

--- a/presets/npm/CHANGELOG.md
+++ b/presets/npm/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @vrn-deco/boilerplate-preset-npm
 
+## 1.1.0
+
+### Minor Changes
+
+- Fall back to `npm` if the selected package manager does not exist
+
+## 1.0.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @vrn-deco/boilerplate-preset-base@1.1.0
+
 ## 1.0.5
 
 ### Patch Changes

--- a/presets/npm/package.json
+++ b/presets/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-preset-npm",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "boilerplate preset npm package installer",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/scripts/new/boilerplate.ts
+++ b/scripts/new/boilerplate.ts
@@ -116,7 +116,7 @@ export async function createBoilerplatePackage() {
   logger.stopLoading()
 
   // add new boilerplate package to minifest package.json
-  execa.commandSync(`pnpm add -D ${packageName} --filter @vrn-deco/boilerplate-manifest`, {
+  execa.commandSync(`pnpm add -D ${packageName}@* --filter @vrn-deco/boilerplate-manifest`, {
     cwd: _REPO_,
   })
 


### PR DESCRIPTION
- @vrn-deco/boilerplate-preset-base
  - Add cmdIsExists methods
- @vrn-deco/boilerplate-preset-npm
  - Fall back to `npm` if the selected package manager does not exist