### PR TITLE
fix(preset): git initialization hoist

### DIFF
--- a/presets/base/src/index.ts
+++ b/presets/base/src/index.ts
@@ -96,6 +96,9 @@ export class BaseRunner implements Runner {
     const boiDir = path.resolve(this.boiPackageDir, 'boilerplate')
     fs.copySync(boiDir, this.targetDir)
 
+    // git init
+    await this.initGitRepo()
+
     // Subclasses should execute their own default logic
     return false
   }
@@ -110,9 +113,6 @@ export class BaseRunner implements Runner {
       this.execCustomScript(scriptType, scriptFile)
       return true
     }
-
-    // git init
-    await this.initGitRepo()
 
     // Subclasses should execute their own default logic
     return false


### PR DESCRIPTION
Hoist Git initialization tasks from `clean` phase to `install` phase in `preser-base`

Now it will be executed after the file is generated and before the dependencies are installed, to ensure that packages that depend on Git, such as `husky` will execute correctly

resolve #115 