### PR TITLE
chore: update deps

### DIFF
--- a/packages/javascript/vue2-element/CHANGELOG.md
+++ b/packages/javascript/vue2-element/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-javascript-vue2-element
 
+## 2.2.18
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-npm@1.1.2
+
 ## 2.2.17
 
 ### Patch Changes

--- a/packages/javascript/vue2-element/package.json
+++ b/packages/javascript/vue2-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-javascript-vue2-element",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "description": "boilerplate javascript vue2 element",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/javascript/vue2-vant-h5plus/CHANGELOG.md
+++ b/packages/javascript/vue2-vant-h5plus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-javascript-vue-vant-h5plus
 
+## 2.2.18
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-npm@1.1.2
+
 ## 2.2.17
 
 ### Patch Changes

--- a/packages/javascript/vue2-vant-h5plus/package.json
+++ b/packages/javascript/vue2-vant-h5plus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-javascript-vue2-vant-h5plus",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "description": "boilerplate-javascript-vue2-vant-h5plus",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/javascript/vue2-vant/CHANGELOG.md
+++ b/packages/javascript/vue2-vant/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-javascript-vue-vant
 
+## 2.2.18
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-npm@1.1.2
+
 ## 2.2.17
 
 ### Patch Changes

--- a/packages/javascript/vue2-vant/package.json
+++ b/packages/javascript/vue2-vant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-javascript-vue2-vant",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "description": "boilerplate-javascript-vue2-vant",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/python/flask-sqlalchemy/CHANGELOG.md
+++ b/packages/python/flask-sqlalchemy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-python-flask-sqlalchemy
 
+## 1.0.4
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-pip@0.0.4
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/python/flask-sqlalchemy/package.json
+++ b/packages/python/flask-sqlalchemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-python-flask-sqlalchemy",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "boilerplate python flask sqlalchemy",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/typescript/electron-vue3/CHANGELOG.md
+++ b/packages/typescript/electron-vue3/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-typescript-electron-vue3
 
+## 0.0.7
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-npm@1.1.2
+
 ## 0.0.6
 
 ### Patch Changes

--- a/packages/typescript/electron-vue3/package.json
+++ b/packages/typescript/electron-vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-typescript-electron-vue3",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "boilerplate typescript electron vue3",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/typescript/vue3-varlet-h5plus/CHANGELOG.md
+++ b/packages/typescript/vue3-varlet-h5plus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-typescript-vue3-varlet-h5plus
 
+## 0.1.13
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-npm@1.1.2
+
 ## 0.1.12
 
 ### Patch Changes

--- a/packages/typescript/vue3-varlet-h5plus/package.json
+++ b/packages/typescript/vue3-varlet-h5plus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-typescript-vue3-varlet-h5plus",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "boilerplate-typescript-vue3-varlet-h5plus",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/typescript/vue3-varlet/CHANGELOG.md
+++ b/packages/typescript/vue3-varlet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-typescript-vue3-varlet
 
+## 0.1.14
+
+### Patch Changes
+
+- @vrn-deco/boilerplate-preset-npm@1.1.2
+
 ## 0.1.13
 
 ### Patch Changes

--- a/packages/typescript/vue3-varlet/package.json
+++ b/packages/typescript/vue3-varlet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-typescript-vue3-varlet",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "boilerplate typescript vue3 varlet",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/presets/base/CHANGELOG.md
+++ b/presets/base/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-preset-base
 
+## 1.3.1
+
+### Patch Changes
+
+- Hoist Git initialization tasks from clean phase to install phase in preser-base
+
 ## 1.3.0
 
 ### Minor Changes

--- a/presets/base/package.json
+++ b/presets/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-preset-base",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "boilerplate preset base",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/presets/npm/CHANGELOG.md
+++ b/presets/npm/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vrn-deco/boilerplate-preset-npm
 
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @vrn-deco/boilerplate-preset-base@1.3.1
+
 ## 1.1.1
 
 ### Patch Changes

--- a/presets/npm/package.json
+++ b/presets/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-preset-npm",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "boilerplate preset npm package installer",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/presets/pip/CHANGELOG.md
+++ b/presets/pip/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vrn-deco/boilerplate-preset-pip
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @vrn-deco/boilerplate-preset-base@1.3.1
+
 ## 0.0.3
 
 ### Patch Changes

--- a/presets/pip/package.json
+++ b/presets/pip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-preset-pip",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "boilerplate preset pip package installer",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",


### PR DESCRIPTION
Update dependencies affected by @vrn-deco/boilerplate-preset-base@1.3.1 #116 

## Affected Packages

- @vrn-deco/boilerplate-javascript-vue2-element@2.2.18
- @vrn-deco/boilerplate-javascript-vue2-vant@2.2.18
- @vrn-deco/boilerplate-javascript-vue2-vant-h5plus@2.2.18
- @vrn-deco/boilerplate-python-flask-sqlalchemy@1.0.4 
- @vrn-deco/boilerplate-typescript-electron-vue3@0.0.7 
- @vrn-deco/boilerplate-typescript-vue3-varlet@0.1.14 
- @vrn-deco/boilerplate-typescript-vue3-varlet-h5plus@0.1.13
- @vrn-deco/boilerplate-preset-npm@1.1.2
- @vrn-deco/boilerplate-preset-pip@0.0.4
