### PR TITLE
feat(boi): add boilerplate-package category tags

### DIFF
--- a/manifest/CHANGELOG.md
+++ b/manifest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-manifest
 
+## 1.2.5
+
+### Patch Changes
+
+- Update boilerplate category tags
+
 ## 1.2.4
 
 ### Patch Changes

--- a/manifest/package.json
+++ b/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-manifest",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "boilerplate manifest",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/javascript/vue2-element/vrn-boilerplate.json
+++ b/packages/javascript/vue2-element/vrn-boilerplate.json
@@ -5,6 +5,6 @@
   "language": "JavaScript",
   "techStack": "vue2+element",
   "preset": "@vrn-deco/boilerplate-preset-npm",
-  "tags": ["front-end", "pc"],
+  "tags": ["thin", "front-end", "pc"],
   "sort": 35
 }

--- a/packages/javascript/vue2-vant-h5plus/vrn-boilerplate.json
+++ b/packages/javascript/vue2-vant-h5plus/vrn-boilerplate.json
@@ -5,6 +5,6 @@
   "language": "JavaScript",
   "techStack": "vue+vant+h5plus",
   "preset": "@vrn-deco/boilerplate-preset-npm",
-  "tags": ["front-end", "mobile", "app"],
+  "tags": ["thin", "front-end", "mobile", "app"],
   "sort": 32
 }

--- a/packages/javascript/vue2-vant/vrn-boilerplate.json
+++ b/packages/javascript/vue2-vant/vrn-boilerplate.json
@@ -5,6 +5,6 @@
   "language": "JavaScript",
   "techStack": "vue+vant",
   "preset": "@vrn-deco/boilerplate-preset-npm",
-  "tags": ["front-end", "mobile"],
+  "tags": ["thin", "front-end", "mobile"],
   "sort": 31
 }

--- a/packages/python/flask-sqlalchemy/vrn-boilerplate.json
+++ b/packages/python/flask-sqlalchemy/vrn-boilerplate.json
@@ -5,6 +5,6 @@
   "language": "Python",
   "techStack": "flask+sqlalchemy",
   "preset": "@vrn-deco/boilerplate-preset-pip",
-  "tags": ["back-end", "rest-api"],
+  "tags": ["fat", "back-end", "rest-api"],
   "sort": 1
 }

--- a/packages/typescript/electron-vue3/vrn-boilerplate.json
+++ b/packages/typescript/electron-vue3/vrn-boilerplate.json
@@ -5,6 +5,6 @@
   "language": "TypeScript",
   "techStack": "electron+vue3",
   "preset": "@vrn-deco/boilerplate-preset-npm",
-  "tags": ["front-end", "pc", "client"],
+  "tags": ["thin", "front-end", "pc", "client"],
   "sort": 51
 }

--- a/packages/typescript/vue3-varlet-h5plus/vrn-boilerplate.json
+++ b/packages/typescript/vue3-varlet-h5plus/vrn-boilerplate.json
@@ -5,6 +5,6 @@
   "language": "TypeScript",
   "techStack": "vue+varlet+h5plus",
   "preset": "@vrn-deco/boilerplate-preset-npm",
-  "tags": ["front-end", "app"],
+  "tags": ["thin", "front-end", "app"],
   "sort": 32
 }

--- a/packages/typescript/vue3-varlet/vrn-boilerplate.json
+++ b/packages/typescript/vue3-varlet/vrn-boilerplate.json
@@ -5,6 +5,6 @@
   "language": "TypeScript",
   "techStack": "vue3+varlet",
   "preset": "@vrn-deco/boilerplate-preset-npm",
-  "tags": ["front-end", "app"],
+  "tags": ["thin", "front-end", "mobile"],
   "sort": 31
 }


### PR DESCRIPTION
## Features

Add category tags to all `boi-package`

- `empty`: This template only provides peripheral content, such as build layer configuration
- `thin`: This template adds project structure on top of `empty`, some 3rd party library integration and some sample code
- `fat`: This template provides more sample code (maybe you don't need) based on `thin`, or implements some basic business

## Affected packages

- @vrn-deco/boilerplate-javascript-vue2-element@2.2.18
- @vrn-deco/boilerplate-javascript-vue2-vant@2.2.18
- @vrn-deco/boilerplate-javascript-vue2-vant-h5plus@2.2.18
- @vrn-deco/boilerplate-python-flask-sqlalchemy@1.0.4 
- @vrn-deco/boilerplate-typescript-electron-vue3@0.0.7 
- @vrn-deco/boilerplate-typescript-vue3-varlet@0.1.14 
- @vrn-deco/boilerplate-typescript-vue3-varlet-h5plus@0.1.13
- @vrn-deco/boilerplate-preset-npm@1.1.2
- @vrn-deco/boilerplate-preset-pip@0.0.4

resolved #121 