### PR TITLE
fix(boi): boi-package pack miss .gitignore

### DIFF
--- a/.tpl/boi-package/package.json
+++ b/.tpl/boi-package/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {

--- a/manifest/CHANGELOG.md
+++ b/manifest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vrn-deco/boilerplate-manifest
 
+## 1.2.9
+
+### Patch Changes
+
+- Update packages affected by preset
+
 ## 1.2.8
 
 ### Patch Changes

--- a/manifest/package.json
+++ b/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/boilerplate-manifest",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "boilerplate manifest",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/boilerplate#readme",

--- a/packages/javascript/vue2-element/package.json
+++ b/packages/javascript/vue2-element/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {

--- a/packages/javascript/vue2-vant-h5plus/package.json
+++ b/packages/javascript/vue2-vant-h5plus/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {

--- a/packages/javascript/vue2-vant/package.json
+++ b/packages/javascript/vue2-vant/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {

--- a/packages/python/flask-sqlalchemy/package.json
+++ b/packages/python/flask-sqlalchemy/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {

--- a/packages/typescript/electron-vue3/package.json
+++ b/packages/typescript/electron-vue3/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {

--- a/packages/typescript/monorepo-lerna-yarn/package.json
+++ b/packages/typescript/monorepo-lerna-yarn/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {

--- a/packages/typescript/monorepo-pnpm/package.json
+++ b/packages/typescript/monorepo-pnpm/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {

--- a/packages/typescript/nest-typeorm/package.json
+++ b/packages/typescript/nest-typeorm/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {

--- a/packages/typescript/vue3-varlet-h5plus/package.json
+++ b/packages/typescript/vue3-varlet-h5plus/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {

--- a/packages/typescript/vue3-varlet/package.json
+++ b/packages/typescript/vue3-varlet/package.json
@@ -8,6 +8,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "*.{?(m|c)js,sh,py}",
+    "README*.md",
+    "CHANGELOG.md",
+    "vrn-boilerplate.json",
+    "boilerplate/",
+    "boilerplate/.gitignore"
+  ],
   "main": "index.js",
   "bin": "index.js",
   "repository": {


### PR DESCRIPTION
`.gitignore` files are excluded from npm packaging, resulting in missing `.gitignore` files in `boi-package/boilerplate`

Resolved by explicitly including `boilerplate/.gitignore` in `fields`

[https://docs.npmjs.com/cli/v8/using-npm/developers#keeping-files-out-of-your-package](https://docs.npmjs.com/cli/v8/using-npm/developers#keeping-files-out-of-your-package)

## Affected Packages

ALL `boi-package`
